### PR TITLE
指定订阅内容到文件

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -53,16 +53,26 @@ func ReadConfig(name string) (*types.Config, error) {
 
 // GetSub 从url中获取订阅信息并进行base64解码
 // http请求错误不发送任何信息; 解码错误发送nil
-func GetSub(url string, ch chan<- []string) {
-	body, err := httpGet(url)
-	if err != nil {
-		body, err = httpGet(url) // 尝试两次
+func GetSub(subscribeDataFilePath string, url string, ch chan<- []string) {
+	var bodyStr string
+
+	if len(subscribeDataFilePath) > 0 {
+		contentBytes, err := os.ReadFile(subscribeDataFilePath)
 		if err != nil {
-			return // send none
+			return
 		}
+		bodyStr = string(contentBytes)
+	} else {
+		body, err := httpGet(url)
+		if err != nil {
+			body, err = httpGet(url) // 尝试两次
+			if err != nil {
+				return // send none
+			}
+		}
+		bodyStr = string(body)
 	}
 
-	bodyStr := string(body)
 	complementLen := (4 - (len(bodyStr) % 4)) % 4
 
 	for i := 0; i < complementLen; i++ {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ var (
 
 		socksPort uint
 		httpPort  uint
+
+		subscribeDataFilePath string
 	}{}
 )
 
@@ -53,6 +55,7 @@ func main() {
 	flag.BoolVar(&flags.version, "version", false, "显示版本")
 	flag.UintVar(&flags.socksPort, "socks", 0, "socks 监听端口")
 	flag.UintVar(&flags.httpPort, "http", 0, "http 监听端口")
+	flag.StringVar(&flags.subscribeDataFilePath, "sub_data", "", "订阅连接的文件内容")
 
 	flag.Parse()
 
@@ -90,18 +93,20 @@ func main() {
 			cfg.SubUrl = flags.url
 		}
 
-		if cfg.SubUrl == "" {
-			fmt.Print("输入订阅地址:")
-			_, _ = fmt.Scan(&cfg.SubUrl)
-		} else {
-			fmt.Printf("订阅地址: %s\n", cfg.SubUrl)
+		if len(flags.subscribeDataFilePath) == 0 {
+			if cfg.SubUrl == "" {
+				fmt.Print("输入订阅地址:")
+				_, _ = fmt.Scan(&cfg.SubUrl)
+			} else {
+				fmt.Printf("订阅地址: %s\n", cfg.SubUrl)
+			}
 		}
 
 		fmt.Println("开始解析订阅信息...")
 
 		var nodes types.Nodes
 		subCh := make(chan []string, 1)
-		go GetSub(cfg.SubUrl, subCh)
+		go GetSub(flags.subscribeDataFilePath, cfg.SubUrl, subCh)
 		defer close(subCh)
 		select {
 		case <-time.After(waitingForSub):


### PR DESCRIPTION
有些链接无法直接获取内容：
<img width="630" alt="image" src="https://github.com/arkrz/v2sub/assets/54064811/f4c0e553-0de8-468b-9ec5-f2b1d9597426">
<img width="1270" alt="image" src="https://github.com/arkrz/v2sub/assets/54064811/b0943e99-d7fa-41a6-9bb0-e6cc6ab9f7ba">

有时，无法直接通过http获取订阅链接中的内容。
这个时候通过手动下载base64编码的订阅连接中的内容。
并指定到参数-sub_data中，后续自动解析即可。